### PR TITLE
js/sandbox/car: 조이스틱 페이드아웃, 메뉴 단순화, 캐시 버스팅 자동화, 가로 모드 레이아웃 수정

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *js/sandbox/car/js/*.js) idx=\"$CLAUDE_PROJECT_DIR/js/sandbox/car/index.html\"; cur=$(grep -oE '\\?v=[0-9]+' \"$idx\" | grep -oE '[0-9]+' | sort -n | tail -1); next=$((cur+1)); sed -i -E \"s/\\?v=[0-9]+/?v=$next/g\" \"$idx\";; esac 2>/dev/null || true",
+            "statusMessage": "Bumping car cache-busting version"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/js/sandbox/car/index.html
+++ b/js/sandbox/car/index.html
@@ -21,8 +21,8 @@
   #hud{position:fixed;top:12px;right:12px;color:#fff;background:rgba(0,0,0,.55);padding:8px 14px;border-radius:10px;font-size:14px;line-height:1.8;white-space:pre;z-index:10;display:none;font-variant-numeric:tabular-nums;}
   #recalBtn{position:fixed;bottom:24px;left:50%;transform:translateX(-50%);padding:12px 28px;border:none;border-radius:999px;font-size:14px;font-weight:700;background:rgba(255,212,0,.92);color:#111;cursor:pointer;z-index:10;display:none;box-shadow:0 2px 12px rgba(0,0,0,.4);transition:opacity .35s;}
   #recalBtn.faded{opacity:0;pointer-events:none;}
-  #joystick{position:fixed;left:0;top:0;width:130px;height:130px;margin:-65px 0 0 -65px;border-radius:50%;border:2px solid rgba(255,255,255,.35);background:rgba(255,255,255,.08);z-index:12;pointer-events:none;opacity:0;transition:opacity .18s;}
-  #joystick.on{opacity:1;}
+  #joystick{position:fixed;left:0;top:0;width:130px;height:130px;margin:-65px 0 0 -65px;border-radius:50%;border:2px solid rgba(255,255,255,.35);background:rgba(255,255,255,.08);z-index:12;pointer-events:none;opacity:0;transition:opacity 1s;}
+  #joystick.on{opacity:1;transition:opacity 0s;}
   #stick{position:absolute;left:50%;top:50%;width:58px;height:58px;border-radius:50%;background:rgba(255,212,0,.9);box-shadow:0 2px 14px rgba(0,0,0,.5);transform:translate(-50%,-50%);will-change:transform;}
   #returnBtn{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);padding:18px 52px;border:none;border-radius:999px;font-size:clamp(1rem,3vw,1.25rem);font-weight:800;background:#ffd400;color:#111;cursor:pointer;z-index:15;display:none;box-shadow:0 4px 28px rgba(255,212,0,.55);transition:transform .1s;}
   #returnBtn:active{transform:translate(-50%,-50%) scale(.95)}

--- a/js/sandbox/car/index.html
+++ b/js/sandbox/car/index.html
@@ -10,7 +10,7 @@
   #c{display:block;width:100%;height:100%;-webkit-touch-callout:none;user-select:none;}
   #overlay{
     position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;
-    background:rgba(0,0,0,.72);z-index:20;
+    background:rgba(0,0,0,.72);z-index:20;overflow-y:auto;padding:24px 16px;
   }
   #overlay h1{color:#ffd400;font-size:clamp(2rem,7vw,4rem);font-weight:900;letter-spacing:4px;margin-bottom:10px;text-shadow:0 2px 20px rgba(255,212,0,.5);}
   #overlay p{color:#ccc;font-size:clamp(.8rem,2.5vw,.95rem);margin-bottom:36px;text-align:center;max-width:300px;line-height:1.8;}
@@ -35,7 +35,7 @@
       도시를 선택하세요.<br>
       <span style="font-size:.8em;color:#888;">기기 기울기·가상 조이스틱·방향키로 주행</span>
     </p>
-    <div style="display:flex;gap:16px;margin-bottom:0;">
+    <div style="display:flex;flex-wrap:wrap;justify-content:center;gap:16px;margin-bottom:0;">
       <button class="mapBtn" id="btnParis">🗼 Paris</button>
       <button class="mapBtn" id="btnRandom">🎲 Random</button>
     </div>

--- a/js/sandbox/car/index.html
+++ b/js/sandbox/car/index.html
@@ -56,15 +56,15 @@
 <script type="importmap">{"imports":{
   "three":"https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
   "three/addons/":"https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/",
-  "./js/scene.js":"./js/scene.js?v=4",
-  "./js/car.js":"./js/car.js?v=4",
-  "./js/input.js":"./js/input.js?v=4",
-  "./js/physics.js":"./js/physics.js?v=4",
-  "./js/state.js":"./js/state.js?v=4",
-  "./js/ui.js":"./js/ui.js?v=4",
-  "./js/constants.js":"./js/constants.js?v=4",
-  "./js/map.js":"./js/map.js?v=4"
+  "./js/scene.js":"./js/scene.js?v=6",
+  "./js/car.js":"./js/car.js?v=6",
+  "./js/input.js":"./js/input.js?v=6",
+  "./js/physics.js":"./js/physics.js?v=6",
+  "./js/state.js":"./js/state.js?v=6",
+  "./js/ui.js":"./js/ui.js?v=6",
+  "./js/constants.js":"./js/constants.js?v=6",
+  "./js/map.js":"./js/map.js?v=6"
 }}</script>
-<script type="module" src="js/main.js?v=4"></script>
+<script type="module" src="js/main.js?v=6"></script>
 </body>
 </html>

--- a/js/sandbox/car/index.html
+++ b/js/sandbox/car/index.html
@@ -16,8 +16,6 @@
   #overlay p{color:#ccc;font-size:clamp(.8rem,2.5vw,.95rem);margin-bottom:36px;text-align:center;max-width:300px;line-height:1.8;}
   .mapBtn{padding:18px 36px;border:2px solid rgba(255,212,0,.5);border-radius:16px;font-size:clamp(1rem,3vw,1.2rem);font-weight:800;background:rgba(255,212,0,.12);color:#ffd400;cursor:pointer;transition:background .15s,transform .1s;}
   .mapBtn:hover,.mapBtn:active{background:rgba(255,212,0,.28);transform:scale(.97);}
-  #startBtn{padding:16px 56px;border:none;border-radius:999px;font-size:clamp(1rem,3vw,1.25rem);font-weight:800;background:#ffd400;color:#111;cursor:pointer;box-shadow:0 4px 28px rgba(255,212,0,.45);transition:transform .1s,box-shadow .1s;}
-  #startBtn:active{transform:scale(.95)}
   #hud{position:fixed;top:12px;right:12px;color:#fff;background:rgba(0,0,0,.55);padding:8px 14px;border-radius:10px;font-size:14px;line-height:1.8;white-space:pre;z-index:10;display:none;font-variant-numeric:tabular-nums;}
   #recalBtn{position:fixed;bottom:24px;left:50%;transform:translateX(-50%);padding:12px 28px;border:none;border-radius:999px;font-size:14px;font-weight:700;background:rgba(255,212,0,.92);color:#111;cursor:pointer;z-index:10;display:none;box-shadow:0 2px 12px rgba(0,0,0,.4);transition:opacity .35s;}
   #recalBtn.faded{opacity:0;pointer-events:none;}
@@ -41,10 +39,6 @@
       <button class="mapBtn" id="btnParis">🗼 Paris</button>
       <button class="mapBtn" id="btnRandom">🎲 Random</button>
     </div>
-  </div>
-  <div id="startPanel" style="display:none;flex-direction:column;align-items:center;gap:16px;">
-    <p id="startDesc" style="color:#ccc;font-size:.9rem;text-align:center;max-width:300px;line-height:1.8;"></p>
-    <button id="startBtn">GAME START</button>
   </div>
 </div>
 <div id="hud"></div>

--- a/js/sandbox/car/js/input.js
+++ b/js/sandbox/car/js/input.js
@@ -47,11 +47,13 @@ function moveStick(x,y){
   stickEl.style.transform=`translate(calc(-50% + ${dx}px), calc(-50% + ${dy}px))`;
 }
 function fadeOutJoystick(){
-  // Begin a 1s CSS fade-out (base transition:opacity 1s), then remove.
-  joyEl.classList.remove('on');
-  if(recalBtnRef) recalBtnRef.classList.remove('faded');
+  // Stay fully visible for 1s, then begin a 1s CSS fade-out, then remove.
   clearTimeout(hideTimer);
-  hideTimer=setTimeout(()=>{ joyVisible=false; }, 1000);
+  hideTimer=setTimeout(()=>{
+    joyEl.classList.remove('on');                       // start 1s CSS fade-out
+    if(recalBtnRef) recalBtnRef.classList.remove('faded');
+    hideTimer=setTimeout(()=>{ joyVisible=false; }, 1000);
+  }, 1000);
 }
 
 let recalBtnRef = null;

--- a/js/sandbox/car/js/input.js
+++ b/js/sandbox/car/js/input.js
@@ -31,10 +31,11 @@ let touchId = null;
 let holdTimer = null, hideTimer = null;
 
 function showJoystick(x,y){
+  clearTimeout(hideTimer);          // cancel any pending fade-out cleanup
   joyOX=x; joyOY=y; joyDX=0; joyDY=0;
   joyEl.style.left=x+'px'; joyEl.style.top=y+'px';
   stickEl.style.transform='translate(-50%,-50%)';
-  joyEl.classList.add('on');
+  joyEl.classList.add('on');        // instant activation (transition:0s)
   if(recalBtnRef) recalBtnRef.classList.add('faded');
   joyVisible=true; joyActive=true;
 }
@@ -45,10 +46,12 @@ function moveStick(x,y){
   joyDX=dx; joyDY=dy;
   stickEl.style.transform=`translate(calc(-50% + ${dx}px), calc(-50% + ${dy}px))`;
 }
-function hideJoystick(){
-  joyVisible=false;
+function fadeOutJoystick(){
+  // Begin a 1s CSS fade-out (base transition:opacity 1s), then remove.
   joyEl.classList.remove('on');
   if(recalBtnRef) recalBtnRef.classList.remove('faded');
+  clearTimeout(hideTimer);
+  hideTimer=setTimeout(()=>{ joyVisible=false; }, 1000);
 }
 
 let recalBtnRef = null;
@@ -66,7 +69,6 @@ export function initJoystick(canvasEl, recalBtn, gameOnGetter){
     const t=e.changedTouches[0];
     touchId=t.identifier;
     const x=t.clientX, y=t.clientY;
-    clearTimeout(hideTimer);
     clearTimeout(holdTimer);
     holdTimer=setTimeout(()=>showJoystick(x,y),500);
   },{passive:false});
@@ -86,8 +88,7 @@ export function initJoystick(canvasEl, recalBtn, gameOnGetter){
     if(joyActive){
       joyActive=false; joyDX=0; joyDY=0;
       stickEl.style.transform='translate(-50%,-50%)';
-      clearTimeout(hideTimer);
-      hideTimer=setTimeout(hideJoystick,1000);
+      fadeOutJoystick();
     }
   }
   canvasEl.addEventListener('touchend',endTouch);

--- a/js/sandbox/car/js/ui.js
+++ b/js/sandbox/car/js/ui.js
@@ -4,40 +4,27 @@ import { CONST_SPEED } from './constants.js';
 
 export let gameOn = false;
 
-let overlay, startBtn, hud, recalBtn, returnBtn;
-let mapSelectEl, startPanelEl, startDescEl;
+let overlay, hud, recalBtn, returnBtn;
+let mapSelectEl;
 let selectedMap = null;
 let starting = false;
 
 export function initUI(){
   overlay    = document.getElementById('overlay');
-  startBtn   = document.getElementById('startBtn');
   hud        = document.getElementById('hud');
   recalBtn   = document.getElementById('recalBtn');
   mapSelectEl   = document.getElementById('mapSelect');
-  startPanelEl  = document.getElementById('startPanel');
-  startDescEl   = document.getElementById('startDesc');
 
   document.getElementById('btnParis').addEventListener('click', () => {
     selectedMap = 'paris';
-    mapSelectEl.style.display = 'none';
-    startDescEl.innerHTML = '🗼 파리 지도로 주행합니다.<br><small style="color:#888">모바일: 센서 접근 허용 필요</small>';
-    startPanelEl.style.display = 'flex';
+    startGame();
   });
   document.getElementById('btnRandom').addEventListener('click', () => {
     selectedMap = 'random';
-    mapSelectEl.style.display = 'none';
-    startDescEl.innerHTML = '🎲 랜덤 도시 지도로 주행합니다.<br><small style="color:#888">모바일: 센서 접근 허용 필요</small>';
-    startPanelEl.style.display = 'flex';
+    startGame();
   });
 
-  startBtn.addEventListener('click', startGame);
   recalBtn.addEventListener('click', calibrate);
-
-  // Keyboard shortcut: any key starts if map selected
-  window.addEventListener('keydown', e=>{
-    if(!gameOn && selectedMap) startGame();
-  });
 
   // Init joystick (pass canvas and recalBtn)
   const canvasEl = document.getElementById('c');
@@ -76,6 +63,5 @@ function returnToMenu(){
   gameOn=false;
   selectedMap=null;
   mapSelectEl.style.display='flex';
-  startPanelEl.style.display='none';
   overlay.style.display='flex';
 }


### PR DESCRIPTION
## 변경 사항

- 가상 조이스틱: 손 뗀 뒤 1초 유지 → 1초 페이드아웃, 재터치 시 즉시 활성화
- 지도 선택 버튼 클릭 시 중간 GAME START 패널 없이 바로 게임 시작
- 게임 오버 후 돌아가기 누르면 최초 타이틀 화면으로 복귀
- `.claude/settings.json` PostToolUse 훅: `js/sandbox/car/js/*.js` 수정 시 `index.html`의 `?v=N` 자동 증가
- 가로(landscape) 모드에서 버튼 잘림·정렬 틀어짐 수정 (`flex-wrap:wrap`, `justify-content:center`, `overflow-y:auto`)

---
_Generated by [Claude Code](https://claude.ai/code/session_014UQP1mMKDMmE7toL5CVSr4)_