### PR TITLE
js/sandbox/car: 레이아웃 픽스, 랜덤 시드 매번 변경, 안전지대 조건 변경

### DIFF
--- a/js/sandbox/car/index.html
+++ b/js/sandbox/car/index.html
@@ -12,6 +12,7 @@
     position:fixed;inset:0;display:flex;flex-direction:column;align-items:center;justify-content:center;
     background:rgba(0,0,0,.72);z-index:20;overflow-y:auto;padding:24px 16px;
   }
+  #mapSelect{display:flex;flex-direction:column;align-items:center;width:100%;}
   #overlay h1{color:#ffd400;font-size:clamp(2rem,7vw,4rem);font-weight:900;letter-spacing:4px;margin-bottom:10px;text-shadow:0 2px 20px rgba(255,212,0,.5);}
   #overlay p{color:#ccc;font-size:clamp(.8rem,2.5vw,.95rem);margin-bottom:36px;text-align:center;max-width:300px;line-height:1.8;}
   .mapBtn{padding:18px 36px;border:2px solid rgba(255,212,0,.5);border-radius:16px;font-size:clamp(1rem,3vw,1.2rem);font-weight:800;background:rgba(255,212,0,.12);color:#ffd400;cursor:pointer;transition:background .15s,transform .1s;}
@@ -56,15 +57,15 @@
 <script type="importmap">{"imports":{
   "three":"https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
   "three/addons/":"https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/",
-  "./js/scene.js":"./js/scene.js?v=6",
-  "./js/car.js":"./js/car.js?v=6",
-  "./js/input.js":"./js/input.js?v=6",
-  "./js/physics.js":"./js/physics.js?v=6",
-  "./js/state.js":"./js/state.js?v=6",
-  "./js/ui.js":"./js/ui.js?v=6",
-  "./js/constants.js":"./js/constants.js?v=6",
-  "./js/map.js":"./js/map.js?v=6"
+  "./js/scene.js":"./js/scene.js?v=8",
+  "./js/car.js":"./js/car.js?v=8",
+  "./js/input.js":"./js/input.js?v=8",
+  "./js/physics.js":"./js/physics.js?v=8",
+  "./js/state.js":"./js/state.js?v=8",
+  "./js/ui.js":"./js/ui.js?v=8",
+  "./js/constants.js":"./js/constants.js?v=8",
+  "./js/map.js":"./js/map.js?v=8"
 }}</script>
-<script type="module" src="js/main.js?v=6"></script>
+<script type="module" src="js/main.js?v=8"></script>
 </body>
 </html>

--- a/js/sandbox/car/js/map.js
+++ b/js/sandbox/car/js/map.js
@@ -52,8 +52,7 @@ export function resetMap(){
 
 // ─── buildRandom ─────────────────────────────────────────────────────────────
 export function buildRandom(){
-  // reset RNG seed for deterministic maps
-  _s = 0xdeadbeef;
+  _s = (Date.now() ^ (Math.random() * 0xffffffff)) >>> 0;
 
   for(let i=0;i<5;i++){
     if(rng()<0.5){

--- a/js/sandbox/car/js/scene.js
+++ b/js/sandbox/car/js/scene.js
@@ -339,7 +339,7 @@ export function buildScene(mapType){
     if(start>=0&&MAP_H-start>=MIN_CENTER_LEN)addYellowV(ex,start,MAP_H-1);
   }
 
-  // ─── safety zones: maximal road rectangles ≥ 3×3 ─────────────────────────────
+  // ─── safety zones: road intersections (≥2×2) or open squares (≥5×5) ─────────
   {
     const szH=new Int32Array(MAP_W), szRects=[];
     for(let ty=0;ty<MAP_H;ty++){
@@ -349,7 +349,9 @@ export function buildScene(mapType){
         const ch=tx<MAP_W?szH[tx]:0; let sx=tx;
         while(stk.length&&stk[stk.length-1].h>ch){
           const {x,h:rh}=stk.pop(); const w=tx-x;
-          if(w>=3&&rh>=3) szRects.push({tx1:x,ty1:ty-rh+1,tx2:tx-1,ty2:ty,area:w*rh});
+          const isIntersection = w>=2&&rh>=2;
+          const isOpenSquare   = Math.min(w,rh)>=5;
+          if(isIntersection||isOpenSquare) szRects.push({tx1:x,ty1:ty-rh+1,tx2:tx-1,ty2:ty,area:w*rh});
           sx=x;
         }
         stk.push({x:sx,h:ch});

--- a/js/sandbox/car/test.mjs
+++ b/js/sandbox/car/test.mjs
@@ -189,13 +189,16 @@ test('parkShade 0-5 for park tiles', () => {
   }
 });
 
-test('buildRandom is deterministic (same seed)', () => {
-  // Build twice; results must be identical
+test('buildRandom produces different maps on each call', () => {
   const snapshot1 = tileMap.slice();
   resetMap(); buildRandom();
+  const snapshot2 = tileMap.slice();
+  // Two maps with different random seeds must differ somewhere
+  let differs = false;
   for (let i = 0; i < MAP_W * MAP_H; i++) {
-    assert.equal(tileMap[i], snapshot1[i], `tile[${i}] differs on second build`);
+    if (snapshot1[i] !== snapshot2[i]) { differs = true; break; }
   }
+  assert.ok(differs, 'buildRandom produced identical maps twice — seed not randomized');
 });
 
 


### PR DESCRIPTION
- CSS: `#mapSelect`에 `display:flex; flex-direction:column; align-items:center` 추가 → 세로/가로 모드 모두 텍스트·버튼 중앙 정렬
- 랜덤 맵: `Date.now() ^ Math.random()` 시드로 매번 다른 지도 생성
- 안전지대: 도로 교차 지점(2×2 이상) 또는 5×5+ 정사각형에만 표시되도록 조건 변경

---
_Generated by [Claude Code](https://claude.ai/code/session_014UQP1mMKDMmE7toL5CVSr4)_