### PR TITLE
캐시 버스팅 v10, 안전지대·아크 수정

### DIFF
--- a/js/sandbox/car/index.html
+++ b/js/sandbox/car/index.html
@@ -57,15 +57,15 @@
 <script type="importmap">{"imports":{
   "three":"https://cdn.jsdelivr.net/npm/three@0.160.0/build/three.module.js",
   "three/addons/":"https://cdn.jsdelivr.net/npm/three@0.160.0/examples/jsm/",
-  "./js/scene.js":"./js/scene.js?v=8",
-  "./js/car.js":"./js/car.js?v=8",
-  "./js/input.js":"./js/input.js?v=8",
-  "./js/physics.js":"./js/physics.js?v=8",
-  "./js/state.js":"./js/state.js?v=8",
-  "./js/ui.js":"./js/ui.js?v=8",
-  "./js/constants.js":"./js/constants.js?v=8",
-  "./js/map.js":"./js/map.js?v=8"
+  "./js/scene.js":"./js/scene.js?v=10",
+  "./js/car.js":"./js/car.js?v=10",
+  "./js/input.js":"./js/input.js?v=10",
+  "./js/physics.js":"./js/physics.js?v=10",
+  "./js/state.js":"./js/state.js?v=10",
+  "./js/ui.js":"./js/ui.js?v=10",
+  "./js/constants.js":"./js/constants.js?v=10",
+  "./js/map.js":"./js/map.js?v=10"
 }}</script>
-<script type="module" src="js/main.js?v=8"></script>
+<script type="module" src="js/main.js?v=10"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- 안전지대 종횡비 3:1 이하로 제한 (직선 도로에 안전지대 생성 방지)
- NE·SW 코너 아크 회전 180° 수정
- 캐시 버스팅 버전 v10으로 업데이트

---
_Generated by [Claude Code](https://claude.ai/code/session_014UQP1mMKDMmE7toL5CVSr4)_